### PR TITLE
Update UnitPromotions.json

### DIFF
--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -2,6 +2,6 @@
 
 {
 		"name": "Guerrillero ability",
-		"uniques": ["Ignores terrain cost","Invisible to non-adjacent units","May withdraw before melee ([80]%)","May enter foreign tiles without open borders"]
+		"uniques": ["Ignores terrain cost","Invisible to non-adjacent units","May withdraw before melee ([80]%)"]
 	},
 ]


### PR DESCRIPTION
Nerfs the Guerrillero by removing its ability to enter enemy tiles without open borders.