### PR TITLE
Revert "Update UnitPromotions.json"

### DIFF
--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -2,6 +2,6 @@
 
 {
 		"name": "Guerrillero ability",
-		"uniques": ["Ignores terrain cost","Invisible to non-adjacent units","May withdraw before melee ([80]%)"]
+		"uniques": ["Ignores terrain cost","Invisible to non-adjacent units","May withdraw before melee ([80]%)","May enter foreign tiles without open borders"]
 	},
 ]


### PR DESCRIPTION
Reverts ArchDuque-Pancake/Latin-American_Civs#25
 
I'm sorry, I think it's actually a better idea to keep it. You can close the PR without merging if you don't want the ability.